### PR TITLE
update python action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -210,6 +210,8 @@ jobs:
 
       - name: Configure Python
         uses: actions/setup-python@v5.1.1
+        with:
+          python-version: 3.13
 
       - name: Python
         run: python HelloWorld.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,7 +211,7 @@ jobs:
       - name: Configure Python
         uses: actions/setup-python@v5.1.1
         with:
-          python-version: 3.13
+          python-version: 3.12.4
 
       - name: Python
         run: python HelloWorld.py


### PR DESCRIPTION
Fix warnings:
```
Warning: Neither 'python-version' nor 'python-version-file' inputs were supplied. Attempting to find '.python-version' file.
Warning: .python-version doesn't exist.
Warning: The `python-version` input is not set.  The version of Python currently in `PATH` will be used.
```